### PR TITLE
Bumped required Java version to 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Java Version](https://img.shields.io/badge/Java%20Version-17-blue)
+
 # MCDC
 A [Minecraft](https://www.minecraft.net) plugin for [paper servers](https://papermc.io).
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <description>A Spigot plugin for cross communicating with a discord server</description>
     <properties>
-        <java.version>15</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <url>https://github.com/MaFeLP/MCDC</url>


### PR DESCRIPTION
This Updates the Java Build version to 17, as Java 17 compilation is required for Minecraft 1.18

Fixes #42

Signed-off-by: MaFeLP <60669873+MaFeLP@users.noreply.github.com>
